### PR TITLE
bugfix(plugins-bundle): single table inheritance type

### DIFF
--- a/bundles/PluginBundle/Model/PluginModel.php
+++ b/bundles/PluginBundle/Model/PluginModel.php
@@ -150,6 +150,10 @@ class PluginModel extends FormModel
 
         foreach ($pluginsMetadata as $bundleName => $pluginMetadata) {
             foreach ($pluginMetadata as $meta) {
+                if ($meta->isInheritanceTypeSingleTable() && !$meta->isRootEntity()) {
+                    continue;
+                }
+
                 $table = $meta->getTableName();
 
                 if (!isset($installedPluginsTables[$bundleName])) {


### PR DESCRIPTION
### The context

In case of multiple entities that share the same DB table (single table inheritance type), we end up with the same table definition for each of the Entity/Metadata, in `PluginModel::getInstalledPluginTables()`. 

### The issue
This behavior results in a conflict, in `PluginModel::createPluginSchemas()` when creating the schema based on tables list.
![image](https://user-images.githubusercontent.com/4104165/150528397-bfd273aa-0770-406f-a87c-0e16e70b53d9.png)


### The fix
This PR aims to fix the issue by collecting a single table in case of multiple entities with single table inheritance type.